### PR TITLE
Updated title css globally

### DIFF
--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -15,6 +15,14 @@ body {
 }
 h1.title {
   font-family: "Inter", sans-serif;
+  font-size: 2.3em;
+  font-weight: 600;
+}
+@media screen and (max-width: 720px) {
+  h1.title {
+    width: 100%;
+    font-size: 2.01em;
+  }
 }
 a {
   color: #9300B8;

--- a/src/components/home/About.svelte
+++ b/src/components/home/About.svelte
@@ -28,15 +28,6 @@
   .About
     padding: 1em 15vw 3em
 
-  :global(h1.about-title)
-    h1.title
-      font-size: 2.3em
-      font-weight: 600
-
-      @media screen and (max-width: 720px)
-        width: 100%
-        font-size: 2.01em
-
   :global(p.about-description)
     font-size: 1em
     line-height: 1.7rem

--- a/src/views/Home.svelte
+++ b/src/views/Home.svelte
@@ -11,10 +11,10 @@
 <Hero />
 <LatestTrades />
 <About>
-  <h1 class="about-title">What are PSTs?</h1>
+  <h1 class="title">What are PSTs?</h1>
   <p class="about-description">Profit Sharing Tokens, or PSTs, are a new incentivization mechanism for the open web that allow developers to earn a stream of micro-dividends for the duration their application is used. (<a href="https://medium.com/@arweave/profit-sharing-tokens-a-new-incentivization-mechanism-for-an-open-web-1f2532411d6e">Source</a>)<br><br>In order for PSTs to have value, however, they need to be able to be exchanged for other PSTs or AR. This is where coinary comes in...</p>
 </About>
 <About>
-  <h1 class="about-title">Why Coinary?</h1>
+  <h1 class="title">Why Coinary?</h1>
   <p class="about-description">Coinary is a completely decentralized network of trading posts built on top of the blockweave. Anyone can host their own trading post and power the exchange, while also being incentivized to do so. With coinary, you can pick the trading post you'd like to use and exchange your PSTs freely!<br><br>Decisions for coinary are made by our very own PST DAO, which means that anyone can have a say in the direction of our platform.</p>
 </About>


### PR DESCRIPTION
This PR introduces a fix to the `about-title` class not having the correct styling, but it also updates the `title` class globally. I'm not sure if Marton intends for this to be the case, which is why this is a PR. 

Feel free to close this if I'm wrongly assuming the global styling, Marton.

CC: @martonlederer 